### PR TITLE
Adds support for Compatility renderer

### DIFF
--- a/addons/simplegrasstextured/plugin.gd
+++ b/addons/simplegrasstextured/plugin.gd
@@ -224,6 +224,8 @@ func _enable_plugin():
 func _disable_plugin():
 	_enable_shaders(false)
 	remove_autoload_singleton("SimpleGrass")
+	if ProjectSettings.has_setting("shader_globals/sgt_legacy_renderer"):
+		ProjectSettings.set_setting("shader_globals/sgt_legacy_renderer", null)
 	if ProjectSettings.has_setting("shader_globals/sgt_player_position"):
 		ProjectSettings.set_setting("shader_globals/sgt_player_position", null)
 	if ProjectSettings.has_setting("shader_globals/sgt_player_mov"):
@@ -388,6 +390,15 @@ func _forward_3d_gui_input(viewport_camera: Camera3D, event: InputEvent) -> int:
 
 
 func _verify_global_shader_parameters():
+	if not ProjectSettings.has_setting("shader_globals/sgt_legacy_renderer"):
+		ProjectSettings.set_setting("shader_globals/sgt_legacy_renderer", {
+			"type": "int",
+			"value": 0
+		})
+		if RenderingServer.global_shader_parameter_get("sgt_legacy_renderer") == null:
+			var using_legacy_renderer = ProjectSettings.get_setting_with_override("rendering/renderer/rendering_method")	== "gl_compatibility"
+			RenderingServer.global_shader_parameter_add("sgt_legacy_renderer", RenderingServer.GLOBAL_VAR_TYPE_INT, 1 if using_legacy_renderer else 0)
+	
 	if not ProjectSettings.has_setting("shader_globals/sgt_player_position"):
 		ProjectSettings.set_setting("shader_globals/sgt_player_position", {
 			"type": "vec3",

--- a/addons/simplegrasstextured/shaders/distance.gdshader
+++ b/addons/simplegrasstextured/shaders/distance.gdshader
@@ -26,12 +26,16 @@ render_mode blend_mix,depth_draw_never,cull_back,unshaded,ambient_light_disabled
 uniform sampler2D heightmap_texture : hint_default_white, repeat_disable, filter_nearest;
 uniform sampler2D depth_texture : hint_depth_texture, repeat_disable, filter_nearest;
 
+global uniform int sgt_legacy_renderer = 0;
 
 void fragment() {
 	vec2 uv = SCREEN_UV;
 	uv.y = 1.0 - uv.y;
 	float depth = textureLod(depth_texture, uv, 0.0).r;
-	vec4 upos = INV_PROJECTION_MATRIX * vec4(uv * 2.0 - 1.0, depth, 1.0);
+	
+	// If using Compatibility renderer, apply proper depth range
+	vec3 ndc = mix(vec3(uv * 2.0 - 1.0, depth), vec3(uv, depth) * 2.0 - 1.0, float(sgt_legacy_renderer));
+	vec4 upos = INV_PROJECTION_MATRIX * vec4(ndc, 1.0);
 	float pos_y = -upos.z + CAMERA_POSITION_WORLD.y;
 	vec3 color_h = textureLod(heightmap_texture, UV, 0).rgb;
 	highp float map_y = (((round(color_h.r * 255.0) - 75.0) * 180.0) + (round(color_h.g * 255.0) - 75.0) + color_h.b) - 16200.0;

--- a/addons/simplegrasstextured/singleton.gd
+++ b/addons/simplegrasstextured/singleton.gd
@@ -67,6 +67,9 @@ func _ready() -> void:
 	elif OS.get_name() == "Android" or OS.get_name() == "iOS":
 		_RESOLUTION = 256.0
 	_PIXEL_STEEP = Vector3(50.0 / _RESOLUTION, 50.0 / _RESOLUTION, 50.0 / _RESOLUTION)
+	var using_legacy_renderer = ProjectSettings.get_setting_with_override("rendering/renderer/rendering_method") == "gl_compatibility"
+	RenderingServer.global_shader_parameter_set(&"sgt_legacy_renderer", 1 if using_legacy_renderer else 0)
+	
 	wind_direction = ProjectSettings.get_setting("shader_globals/sgt_wind_direction", {"value":wind_direction}).value
 	wind_strength = ProjectSettings.get_setting("shader_globals/sgt_wind_strength", {"value":wind_strength}).value
 	wind_turbulence = ProjectSettings.get_setting("shader_globals/sgt_wind_turbulence", {"value":wind_turbulence}).value


### PR DESCRIPTION
The assets works overall, but grass displacement does not work properly due to the displacement render texture utilizing the depth texture, and the depth calculations assumes Vulkan depth range which differs from OpenGL.

This PR adds an additional shader global, which is updated in singleton.gd._ready(), setting the value to 0 or 1 based on the renderer used. distance.gdshader uses this value to set the appropriate vec3 to use when calculating depth.

This allows for using the asset with either renderer devices without manually modifying the shader.

