### PR TITLE
Improved grass node transformation support

### DIFF
--- a/addons/simplegrasstextured/grass.gd
+++ b/addons/simplegrasstextured/grass.gd
@@ -639,7 +639,7 @@ func _update_height_map() -> void:
 	)
 	_node_height_map.global_position = global_position + (global_basis * align)
 	_node_height_map.global_rotation = global_rotation
-
+	_node_height_map.visible = visible
 
 func _update_material_shader() -> bool:
 	var shader_name := "grass"

--- a/addons/simplegrasstextured/grass.gd
+++ b/addons/simplegrasstextured/grass.gd
@@ -637,8 +637,8 @@ func _update_height_map() -> void:
 		0,
 		(aabb.position.z + (aabb.size.z / 2.0))
 	)
-	_node_height_map.global_position = global_position + align
-	_node_height_map.visible = visible
+	_node_height_map.global_position = global_position + (global_basis * align)
+	_node_height_map.global_rotation = global_rotation
 
 
 func _update_material_shader() -> bool:

--- a/addons/simplegrasstextured/plugin.gd
+++ b/addons/simplegrasstextured/plugin.gd
@@ -819,7 +819,7 @@ func _eval_brush() -> void:
 					if not follow_normal:
 						normal = Vector3.UP
 					list_trans.append(_grass_selected.eval_grass_transform(
-						_raycast_3d.get_collision_point() - _grass_selected.global_position,
+						_grass_selected.to_local(_raycast_3d.get_collision_point()),
 						normal,
 						_edit_scale,
 						deg_to_rad(_edit_rotation) + (PI * (_edit_rotation_rand - (randf() * _edit_rotation_rand * 2.0)))
@@ -856,7 +856,7 @@ func _eval_brush() -> void:
 				if not follow_normal:
 					normal = Vector3.UP
 				_grass_selected.add_grass(
-					_raycast_3d.get_collision_point() - _grass_selected.global_position,
+					_grass_selected.to_local(_raycast_3d.get_collision_point()),
 					normal,
 					_edit_scale,
 					deg_to_rad(_edit_rotation) + (PI * (_edit_rotation_rand - (randf() * _edit_rotation_rand * 2.0)))
@@ -864,7 +864,7 @@ func _eval_brush() -> void:
 	elif _edit_tool == TOOL.ERASER:
 		match _grass_selected.sgt_tool_shape["eraser"]:
 			TOOL_SHAPE.SPHERE:
-				_grass_selected.erase(_position_draw - _grass_selected.global_position, _edit_radius)
+				_grass_selected.erase(_grass_selected.to_local(_position_draw), _edit_radius)
 			TOOL_SHAPE.CYLINDER:
 				_grass_selected.erase_cylinder(_edit_radius, _pointer_depth, _edit_radius, _pointer_decal.global_transform)
 			TOOL_SHAPE.CYLINDER_INF_H:


### PR DESCRIPTION
**Issue:**
When scaling and rotating the SimpleGrass nodes or its parents drawing onto them has unexpected behaviour, grass is drawn in other locations. 
When scaling and rotating the SimpleGrass nodes or its parents don't work as expected in interactive mode while running the game, some grass moves, some doesn't.

**Solution:**
Make sure transformations are used.
- use .to_local() method instead of manual subtraction.
- add global basis transformation to the heightmap